### PR TITLE
using latest date first

### DIFF
--- a/_includes/git-wiki/components/lists/page-list.html
+++ b/_includes/git-wiki/components/lists/page-list.html
@@ -7,7 +7,7 @@
         }} updated) {% endif %}:</span>
     <ul class="page-list">
         {% assign numPages=0 %}
-        {% assign items = site.html_pages | sort: 'date' %}
+        {% assign items = site.html_pages | sort: 'date' | reverse %}
         {% for page in items %}
         {% if numPages >= site.show_wiki_pages_limit %}
         {% break %}

--- a/_includes/git-wiki/components/lists/post-list.html
+++ b/_includes/git-wiki/components/lists/post-list.html
@@ -7,7 +7,7 @@
         }} updated) {% endif %}:</span>
     <ul class="post-list">
         {% assign numPages=0 %}
-        {% assign items = site.posts | sort: 'date' %}
+        {% assign items = site.posts | sort: 'date' | reverse %}
         {% for post in items %}
         {% if numPages >= site.show_wiki_posts_limit %}
         {% break %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Using reverse sort by date for page and posts. Current page and posts always show early date as first. The latest modified post can not be shown in sidebar list.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
